### PR TITLE
[FEAT] 메인 및 데일리로그 페이지에서 화면 이동

### DIFF
--- a/src/components/ExistingLogs.jsx
+++ b/src/components/ExistingLogs.jsx
@@ -1,13 +1,19 @@
 import LogItem from "./LogItem";
 import { useLogContext } from "../context/LogContext";
-
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import "./../styles/colors.css";
 
 const ExistingLog = () => {
+    const navigate = useNavigate();
+
     const { logs } = useLogContext();
 
     const recentLogs = logs?.slice(-3).reverse() ?? [];
+
+    const handleClick = () => {
+        navigate("/daily-log")
+    }
 
     return (
         <LogListWrapper>
@@ -17,7 +23,7 @@ const ExistingLog = () => {
                 ))}
             </LogList>
 
-            <ExtraLogButton>
+            <ExtraLogButton onClick={handleClick}>
                 더 많은 로그가 보고 싶으신가요?
             </ExtraLogButton>
         </LogListWrapper>

--- a/src/components/NoLogs.jsx
+++ b/src/components/NoLogs.jsx
@@ -1,12 +1,33 @@
 import styled from "styled-components";
 import "./../styles/colors.css";
 import { useNavigate } from "react-router-dom";
+import { useLogContext } from "../context/LogContext.jsx";
+import { getYear, getMonth, getDate } from "date-fns";
+import axios from "axios";
 
 const NoLogs = () => {
     const navigate = useNavigate();
+    const { selectedDate } = useLogContext();
+    const year = getYear(selectedDate);
+    const month = getMonth(selectedDate) + 1;
+    const day = getDate(selectedDate);
+    
+    // const SERVER_BASE_URL = A`http://mindbullet.kro.kr`;
+    const SERVER_BASE_URL = `http://localhost:8080`;
 
-    const handleClick = () => {
-        navigate("/log-detail")
+    const postBoardUrl = `${SERVER_BASE_URL}/board/${year}/${month}/${day}`;
+
+
+    const handleClick = async() => {
+        try {
+            // 게시판 생성 api
+            await axios.post(postBoardUrl);
+            navigate("/log-detail"); // 성공시, 로그 생성 페이지로 이동
+        }
+        catch(error) {
+            console.log("게시판 생성 실패: ", error);
+            alert("로그 생성에 실패하였습니다.(게시판 생성 실패)");
+        }
     };
 
     return (


### PR DESCRIPTION
## 기능 설명
- 메인 페이지
    - 특정 날짜에 로그가 없는 경우, boardId 생성 후 로그 생성 페이지로 이동
    - 특정 날짜에 로그가 있는 경우, 데일리로그 페이지로 이동
- 데일리 로그 페이지
    - 로그 추가 클릭시, 로그 생성 페이지로 이동(단, boardId가 없다면 생성)
    - 뒤로 가기 버튼 클릭시, 메인 페이지로 이동

- 관련 이슈: #14 